### PR TITLE
removed http import and createserver setup to just use express.

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import http from 'http';
 
 import React from 'react';
 import { renderToString } from 'react-dom/server';
@@ -30,9 +29,10 @@ app.get('*', (req, res) => {
   });
 });
 
-const server = http.createServer(app);
-
-server.listen(3003);
-server.on('listening', () => {
-  console.log('Listening on 3003');
+app.listen(3003, 'localhost', function(err) {
+  if (err) {
+    console.log(err);
+    return;
+  }
+  console.log('Listening at http://localhost:3003');
 });


### PR DESCRIPTION
Hey,

I forked your repo and made a few changes to remove `http` and the createServer setup you had in `server.js` to instead just use the `express` app instance and just listen to it. It's a minor change to have express all the way through without using `http` module.

Great job with the repo 👍
Keep up the great work!
