### PR TITLE
Make repo match the blog article

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "history": "^1.13.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
-    "react-router": "^1.0.0"
+    "react-router": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ import express from 'express';
 
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { match, RoutingContext } from 'react-router';
+import { match, RouterContext } from 'react-router';
 
 import { routes } from './routes';
 
@@ -13,22 +13,29 @@ app.use(express.static('public'));
 app.set('view engine', 'ejs');
 
 app.get('*', (req, res) => {
+  // routes is our object of React routes defined above
   match({ routes, location: req.url }, (err, redirectLocation, props) => {
     if (err) {
+      // something went badly wrong, so 500 with a message
       res.status(500).send(err.message);
     } else if (redirectLocation) {
+      // we matched a ReactRouter redirect, so redirect from the server
       res.redirect(302, redirectLocation.pathname + redirectLocation.search);
     } else if (props) {
-      const markup = renderToString(<RoutingContext {...props} />);
+      // if we got props, that means we found a valid component to render
+      // for the given route
+      const markup = renderToString(<RouterContext {...props} />);
 
+      // render `index.ejs`, but pass in the markup we want it to display
       res.render('index', { markup })
 
     } else {
+      // no route match, so 404. In a real app you might render a custom
+      // 404 view here
       res.sendStatus(404);
     }
   });
 });
-
 app.listen(3003, 'localhost', function(err) {
   if (err) {
     console.log(err);


### PR DESCRIPTION
This PR synchronizes the repo with the desired state of the blog posting at https://24ways.org/2015/universal-react/ 
- Update to make package.json require react-router@^2.0.0
- Update server.js to use "RouterContext" and include comments from blog version

A couple small changes need to occur in the blog posting:
1. Change "RoutingContext" to "RouterContext" in server.js (two places)
2. Remove the require("http") from server.js and switch to app.listen(3003...)
3. Resolve the difference in webpack.config.js `test: /.js$/,` - with or without a '\' before the '.'?

Thanks again!
